### PR TITLE
Fix Metaclass usage for Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Scrapy>=0.24.5
 sqlalchemy
+six

--- a/scrapy_sqlitem/sqlitem.py
+++ b/scrapy_sqlitem/sqlitem.py
@@ -1,6 +1,7 @@
 from scrapy.item import Field, Item, ItemMeta
 
 from sqlalchemy.sql import and_
+from six import with_metaclass
 
 
 class SqlAlchemyItemMeta(ItemMeta):
@@ -26,9 +27,7 @@ class SqlAlchemyItemMeta(ItemMeta):
         return cls
 
 
-class SqlItem(Item):
-
-    __metaclass__ = SqlAlchemyItemMeta
+class SqlItem(with_metaclass(SqlAlchemyItemMeta, Item)):
 
     sqlmodel = None
 


### PR DESCRIPTION
Fix the way SqlAlchemyItemMeta is used in SqlItem to be compatible with
Python 2.x and 3.x.